### PR TITLE
feat: let devs specify an existing secret

### DIFF
--- a/charts/jit-k8s-agent/templates/_job_helper.tpl
+++ b/charts/jit-k8s-agent/templates/_job_helper.tpl
@@ -1,4 +1,5 @@
 {{- define "jit-job-spec" -}}
+{{- $jitCredentialsSecret := .Values.jit.existingSecret | default (printf "%s-jit-credentials" .Chart.Name) -}}
 spec:
   serviceAccountName: {{ .Values.serviceAccount.name }}
   restartPolicy: OnFailure
@@ -19,12 +20,12 @@ spec:
         - name: JIT_CLIENT_ID
           valueFrom:
             secretKeyRef:
-              name: {{ .Chart.Name }}-jit-credentials
+              name: {{ $jitCredentialsSecret }}
               key: JIT_CLIENT_ID
         - name: JIT_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ .Chart.Name }}-jit-credentials
+              name: {{ $jitCredentialsSecret }}
               key: JIT_CLIENT_SECRET
         - name: JIT_API_URL
           value: {{ .Values.jit.apiUrl }}

--- a/charts/jit-k8s-agent/templates/_validation.tpl
+++ b/charts/jit-k8s-agent/templates/_validation.tpl
@@ -1,0 +1,40 @@
+{{/*
+Validate required values and provide clear error messages
+*/}}
+{{- define "jit-k8s-agent.validateValues" -}}
+{{- $errors := list -}}
+
+{{- if not .Values.cluster.name -}}
+{{- $errors = append $errors "cluster.name is required and cannot be empty" -}}
+{{- end -}}
+
+{{- if .Values.jit -}}
+  {{- if and .Values.jit.clientId .Values.jit.clientSecret -}}
+    {{- if .Values.jit.existingSecret -}}
+{{- $errors = append $errors "Cannot specify both direct credentials (clientId/clientSecret) and existingSecret. Choose one authentication method." -}}
+    {{- end -}}
+  {{- else if .Values.jit.existingSecret -}}
+    {{- /* Valid: using existingSecret */ -}}
+  {{- else -}}
+{{- $errors = append $errors "Jit authentication requires either: 1) Both 'clientId' and 'clientSecret' for direct authentication, or 2) 'existingSecret' to reference an existing Kubernetes secret" -}}
+  {{- end -}}
+{{- else -}}
+{{- $errors = append $errors "Jit configuration is required. Please provide either clientId/clientSecret or existingSecret" -}}
+{{- end -}}
+
+{{- if $errors -}}
+{{- $errorMsg := printf "Configuration validation failed:\n" -}}
+{{- range $errors -}}
+{{- $errorMsg = printf "%s  • %s\n" $errorMsg . -}}
+{{- end -}}
+{{- $errorMsg = printf "%s\nExample configurations:\n" $errorMsg -}}
+{{- $errorMsg = printf "%s  # Option 1: Direct credentials\n" $errorMsg -}}
+{{- $errorMsg = printf "%s  jit:\n" $errorMsg -}}
+{{- $errorMsg = printf "%s    clientId: \"your-client-id\"\n" $errorMsg -}}
+{{- $errorMsg = printf "%s    clientSecret: \"your-client-secret\"\n" $errorMsg -}}
+{{- $errorMsg = printf "%s\n  # Option 2: Existing secret\n" $errorMsg -}}
+{{- $errorMsg = printf "%s  jit:\n" $errorMsg -}}
+{{- $errorMsg = printf "%s    existingSecret: \"jit-credentials\"\n" $errorMsg -}}
+{{- fail $errorMsg -}}
+{{- end -}}
+{{- end -}}

--- a/charts/jit-k8s-agent/templates/secret.yaml
+++ b/charts/jit-k8s-agent/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{- include "jit-k8s-agent.validateValues" . -}}
+{{- if not .Values.jit.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +10,5 @@ metadata:
 type: Opaque
 data:
   JIT_CLIENT_ID: {{ .Values.jit.clientId | b64enc }}
-  JIT_CLIENT_SECRET: {{ .Values.jit.clientSecret | b64enc }} 
+  JIT_CLIENT_SECRET: {{ .Values.jit.clientSecret | b64enc }}
+{{- end }}

--- a/charts/jit-k8s-agent/values.schema.json
+++ b/charts/jit-k8s-agent/values.schema.json
@@ -18,16 +18,22 @@
       "properties": {
         "clientId": {
           "type": "string",
-          "minLength": 1,
-          "description": "The client ID for Jit. This field is required."
+          "description": "The client ID for Jit. This field is required when not using an existing secret."
         },
         "clientSecret": {
           "type": "string",
-          "minLength": 1,
-          "description": "The client secret for Jit. This field is required."
+          "description": "The client secret for Jit. This field is required when not using an existing secret."
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "The name of an existing secret to use for Jit credentials. If provided, clientId and clientSecret will be ignored."
+        },
+        "apiUrl": {
+          "type": "string",
+          "description": "The Jit API URL"
         }
       },
-      "required": ["clientId", "clientSecret"]
+      "description": "Jit authentication requires either: 1) Both 'clientId' and 'clientSecret' for direct authentication, or 2) 'existingSecret' to reference an existing Kubernetes secret containing the credentials."
     }
   }
 }

--- a/charts/jit-k8s-agent/values.yaml
+++ b/charts/jit-k8s-agent/values.yaml
@@ -7,8 +7,11 @@ cluster:
   name: "" # Required, set it while installing the chart. Should be unique across all clusters.
 
 jit:
-  clientId: "" # Required, set it while installing the chart
-  clientSecret: "" # Required, set it while installing the chart
+  # clientId and clientSecret are required when not using an existing secret
+  # clientId: ""
+  # clientSecret: ""
+  # existingSecret prevents storing clientId and clientSecret as plain text in the values.yaml file
+  # existingSecret: ""
   apiUrl: https://api.jit.io
 
 kubescape:


### PR DESCRIPTION
Motivation: prevent storing clientId and Secret in Gitops repos

Tests:

```
$ helm template charts/jit-k8s-agent
Error: values don't meet the specifications of the schema(s) in the following chart(s):
jit-k8s-agent:
- cluster.name: String length must be greater than or equal to 1

$ helm template charts/jit-k8s-agent --set cluster.name=test
Error: execution error at (jit-k8s-agent/templates/secret.yaml:1:4): Configuration validation failed:
  • Jit authentication requires either: 1) Both 'clientId' and 'clientSecret' for direct authentication, or 2) 'existingSecret' to reference an existing Kubernetes secret

Example configurations:
  # Option 1: Direct credentials
  jit:
    clientId: "your-client-id"
    clientSecret: "your-client-secret"

  # Option 2: Existing secret
  jit:
    existingSecret: "jit-credentials"


Use --debug flag to render out invalid YAML

$ helm template charts/jit-k8s-agent --set cluster.name=test --set jit.clientId=test --set jit.clientSe
cret=test
---
# Source: jit-k8s-agent/templates/serviceaccount.yaml
[...]
                - name: JIT_CLIENT_ID
                  valueFrom:
                    secretKeyRef:
                      name: jit-k8s-agent-jit-credentials
                      key: JIT_CLIENT_ID
                - name: JIT_CLIENT_SECRET
                  valueFrom:
                    secretKeyRef:
                      name: jit-k8s-agent-jit-credentials
                      key: JIT_CLIENT_SECRET
[...]

$ helm template charts/jit-k8s-agent --set cluster.name=test --set jit.existingSecret=existing-secret
---
# Source: jit-k8s-agent/templates/serviceaccount.yaml
                - name: JIT_CLIENT_ID
                  valueFrom:
                    secretKeyRef:
                      name: existing-secret
                      key: JIT_CLIENT_ID
                - name: JIT_CLIENT_SECRET
                  valueFrom:
                    secretKeyRef:
                      name: existing-secret
                      key: JIT_CLIENT_SECRET
[...]
[...]
```