### PR TITLE
[SC-31363] - Bump version of the Chart

### DIFF
--- a/charts/jit-k8s-agent/Chart.yaml
+++ b/charts/jit-k8s-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: jit-k8s-agent
 description: A Helm chart for the periodic Kubernetes resources collector job
-version: 1.2.1
+version: 1.3.0
 appVersion: "1.0"


### PR DESCRIPTION
Bumps the version of the Chart after the latest changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version for jit-k8s-agent from 1.2.1 to 1.3.0.
  * No functional or user-facing changes; existing deployments and configurations are unaffected.
  * This update only adjusts version metadata used by packaging/distribution.
  * Upgrade paths and compatibility remain the same.
  * Release numbering updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->