### PR TITLE
[SC-31576] - Update `jit-agent` version and `Chart` version

### DIFF
--- a/charts/jit-k8s-agent/Chart.yaml
+++ b/charts/jit-k8s-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: jit-k8s-agent
 description: A Helm chart for the periodic Kubernetes resources collector job
-version: 1.3.0
+version: 1.3.1
 appVersion: "1.0"

--- a/charts/jit-k8s-agent/README.md
+++ b/charts/jit-k8s-agent/README.md
@@ -33,7 +33,7 @@ The following table lists the configurable parameters of the `jit-k8s-agent` cha
 | Parameter                   | Description                                | Default                                 |
 | --------------------------- | ------------------------------------------ | --------------------------------------- |
 | `image.repository`          | Image repository                           | `public.ecr.aws/h8r7r9n6/jit-k8s-agent` |
-| `image.tag`                 | Image tag                                  | `1.2.1`                                 |
+| `image.tag`                 | Image tag                                  | `1.3.0`                                 |
 | `image.pullPolicy`          | Image pull policy                          | `IfNotPresent`                          |
 | `cluster.name`              | Name of the cluster (required) `(1)`       | `""`                                    |
 | `jit.clientId`              | Jit service client ID (required) `(2)`     | `""`                                    |

--- a/charts/jit-k8s-agent/values.yaml
+++ b/charts/jit-k8s-agent/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: public.ecr.aws/h8r7r9n6/jit-k8s-agent
-  tag: 1.2.1
+  tag: 1.3.0
   pullPolicy: IfNotPresent
 
 cluster:


### PR DESCRIPTION
- updates `jit-agent` version 
- updates `Chart` version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped jit-k8s-agent chart version to 1.3.1.
  - Updated the default container image tag to 1.3.0 for new installs and upgrades.
- Documentation
  - Updated README to reflect the new default image tag.

These updates align defaults with the latest image and documentation. No other functional changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->